### PR TITLE
Remove useless decompression/compression in image publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ROS2 package handling Reachy:
 
 **ROS2 Version: Foxy**
 
-Dependencies: [reachy_msgs](https://github.com/pollen-robotics/reachy_msgs), [reachy_pyluos_hal](https://github.com/pollen-robotics/reachy_pyluos_hal), [zoom_kurokesu](https://github.com/pollen-robotics/zoom_kurokesu)
+Dependencies: [reachy_msgs](https://github.com/pollen-robotics/reachy_msgs), [reachy_pyluos_hal](https://github.com/pollen-robotics/reachy_pyluos_hal), [zoom_kurokesu](https://github.com/pollen-robotics/zoom_kurokesu), [v4l2py](https://github.com/tiagocoutinho/v4l2py/blob/master/setup.py).
 
 How to install:
 

--- a/launch/camera_controller.launch.py
+++ b/launch/camera_controller.launch.py
@@ -1,10 +1,14 @@
 from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
 
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     return LaunchDescription([
+        # See: https://github.com/ros2/rosidl_python/issues/79
+        SetEnvironmentVariable('PYTHONOPTIMIZE', '1'),
+
         Node(
             package='reachy_controllers',
             executable='camera_publisher',

--- a/launch/camera_publisher.launch.py
+++ b/launch/camera_publisher.launch.py
@@ -1,10 +1,14 @@
 from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
 
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     return LaunchDescription([
+        # See: https://github.com/ros2/rosidl_python/issues/79
+        SetEnvironmentVariable('PYTHONOPTIMIZE', '1'),
+
         Node(
             package='reachy_controllers',
             executable='camera_publisher',

--- a/launch/reachy_controllers.launch.py
+++ b/launch/reachy_controllers.launch.py
@@ -1,10 +1,14 @@
 from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
 
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     return LaunchDescription([
+        # See: https://github.com/ros2/rosidl_python/issues/79
+        SetEnvironmentVariable('PYTHONOPTIMIZE', '1'),
+
         Node(
             package='reachy_controllers',
             executable='joint_state_controller',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'setuptools',
         'zoom_kurokesu>=1.1',
         'reachy_pyluos_hal',
+        'v4l2py',
     ],
     zip_safe=True,
     maintainer='Pollen-Robotics',


### PR DESCRIPTION
- [x] Use v4l2py to directly access raw JPEG frame
- [x] Feed the CompressedImage data field with the raw JPEG bytes 
- [x] Use the PYTHONOPTIMIZE environment variable to disable the __debug__ checks (https://github.com/ros2/rosidl_python/issues/79)

⚠️ By using raw frame, we can not correct the orientation in the publisher. It could be done automatically in the SDK.