### PR TITLE
Mobile base integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ The callback of this topic uses [reachy_pyluos_hal](https://github.com/pollen-ro
 
 * **/set_fan_state** ([reachy_msgs/srv/SetFanState.srv](https://github.com/pollen-robotics/reachy_msgs/blob/master/srv/SetFanState.srv))[[joint_state_controller](https://github.com/pollen-robotics/reachy_controllers/blob/master/reachy_controllers/joint_state_controller.py)] - Set requested fans to requested state (on or off). 
 
+* **/get_reachy_model** ([reachy_msgs/srv/GetReachyModel.srv](https://github.com/pollen-robotics/reachy_msgs/blob/master/srv/GetReachyModel.srv))[[joint_state_controller](https://github.com/pollen-robotics/reachy_controllers/blob/master/reachy_controllers/joint_state_controller.py)] - Return the model of the Reachy used and the mobile base version, if a mobile base is connected to the robot. 
+
 
 ## Launch files
 

--- a/reachy_controllers/camera_zoom_service.py
+++ b/reachy_controllers/camera_zoom_service.py
@@ -20,7 +20,7 @@ class ZoomControllerService(Node):
         super().__init__('camera_zoom_controller_service')
         self.logger = self.get_logger()
 
-        self.controller = ZoomController()
+        self.controller = ZoomController('/dev/kurokesu')
         self.controller.set_speed(default_zoom_speed)
         for side in ('left', 'right'):
             self.controller.homing(side)

--- a/reachy_controllers/joint_state_controller.py
+++ b/reachy_controllers/joint_state_controller.py
@@ -27,7 +27,7 @@ from reachy_msgs.msg import FanState
 from reachy_msgs.msg import JointTemperature
 from reachy_msgs.msg import PidGains
 from reachy_msgs.srv import GetJointFullState, SetJointCompliancy, SetJointPidGains
-from reachy_msgs.srv import SetFanState
+from reachy_msgs.srv import SetFanState, GetReachyModel
 
 
 def get_reachy_model() -> str:
@@ -37,6 +37,15 @@ def get_reachy_model() -> str:
     https://github.com/pollen-robotics/reachy_pyluos_hal/blob/main/reachy_pyluos_hal/tools/reachy_identify_model.py
     """
     model = check_output(['reachy-identify-model']).strip().decode()
+    return model
+
+
+def get_zuuu_model() -> str:
+    """Find the configuration file for your mobile base.
+    Refer to following link for details on how the identification is done:
+    https://github.com/pollen-robotics/reachy_pyluos_hal/blob/main/reachy_pyluos_hal/tools/reachy_identify_model.py
+    """
+    model = check_output(['reachy-identify-zuuu-model']).strip().decode()
     return model
 
 
@@ -169,6 +178,13 @@ class JointStateController(Node):
         )
         self.logger.info(f'Create "{self.fan_srv.srv_name}" service.')
 
+        self.get_reachy_model_service = self.create_service(
+            srv_type=GetReachyModel,
+            srv_name='get_reachy_model',
+            callback=self.handle_get_reachy_model,
+        )
+        self.logger.info(f'Create "{self.get_reachy_model_service.srv_name}" service.')
+
         self.logger.info('Node ready!')
 
     def shutdown(self) -> None:
@@ -293,6 +309,16 @@ class JointStateController(Node):
 
         return response
 
+    def handle_get_reachy_model(self,
+                                request: GetReachyModel.Request,
+                                response: GetReachyModel.Response,
+                                ) -> GetReachyModel.Response:
+        """Handle GetReachyModel service request."""
+        self.logger.info('Yo')
+        response.reachy_model = get_reachy_model()
+        response.zuuu_model = get_zuuu_model()
+        self.logger.info('Kook')
+        return response
 
 def _val_to_pid_gain(values: List[float]) -> PidGains:
     gains = PidGains()

--- a/reachy_controllers/joint_state_controller.py
+++ b/reachy_controllers/joint_state_controller.py
@@ -42,6 +42,7 @@ def get_reachy_model() -> str:
 
 def get_zuuu_model() -> str:
     """Find the configuration file for your mobile base.
+
     Refer to following link for details on how the identification is done:
     https://github.com/pollen-robotics/reachy_pyluos_hal/blob/main/reachy_pyluos_hal/tools/reachy_identify_model.py
     """
@@ -314,11 +315,10 @@ class JointStateController(Node):
                                 response: GetReachyModel.Response,
                                 ) -> GetReachyModel.Response:
         """Handle GetReachyModel service request."""
-        self.logger.info('Yo')
         response.reachy_model = get_reachy_model()
         response.zuuu_model = get_zuuu_model()
-        self.logger.info('Kook')
         return response
+
 
 def _val_to_pid_gain(values: List[float]) -> PidGains:
     gains = PidGains()

--- a/reachy_controllers/joint_state_controller.py
+++ b/reachy_controllers/joint_state_controller.py
@@ -75,6 +75,7 @@ class JointStateController(Node):
             - /set_joint_compliancy SetJointCompliancy
             - /set_joint_pid SetJointPID
             - /set_fan_state SetFanState
+            - /get_reachy_model GetReachyModel
         """
         super().__init__('joint_state_controller')
 


### PR DESCRIPTION
- Create ROS2 service to get Reachy's model and mobile base's version from Reachy's config file *~/.reachy.yaml*.
This service is required because we need to know whether or not a mobile base is used with Reachy to use the correct teleoperation version.